### PR TITLE
Deduplicator.Deduplicate([]T) returns nil when provided []T{}

### DIFF
--- a/deduplicate.go
+++ b/deduplicate.go
@@ -34,6 +34,9 @@ func (dd *Deduplicator[T]) Reset() {
 // Deduplicate returns a newly allocated slice without duplicate values by comparing it against values previously
 // seen by the Deduplicator{}
 func (dd *Deduplicator[T]) Deduplicate(values []T) []T {
+	if len(values) == 0 {
+		return values
+	}
 	var deduped []T
 	for _, v := range values {
 		if dd.Add(v) {

--- a/deduplicate_test.go
+++ b/deduplicate_test.go
@@ -40,7 +40,7 @@ func (s *DeDuplicateSuite) TestDeduplicateSlice() {
 	s.ElementsMatch(deduped, []int{1, 2, 3, 4, 5, 6})
 
 	deduped = dd.Deduplicate(values)
-	s.Nil(deduped)
+	s.ElementsMatch(deduped, []int{})
 
 	dd.Reset()
 	deduped = dd.Deduplicate(values)
@@ -52,6 +52,20 @@ func (s *DeDuplicateSuite) TestDeduplicateSlice() {
 	dd.Reset()
 	dedupedIndices := dd.DeduplicateIndices(values)
 	s.ElementsMatch(dedupedIndices, []int{3, 7, 8})
+}
+
+func (s *DeDuplicateSuite) TestDeduplicateNilSlice() {
+	s.Run("empty slice should return empty slice", func() {
+		dd := NewDeduplicator[int]()
+		deduped := dd.Deduplicate([]int{})
+		s.Equal(deduped, []int{})
+	})
+
+	s.Run("nil slice should return nil slice", func() {
+		dd := NewDeduplicator[int]()
+		deduped := dd.Deduplicate(nil)
+		s.Nil(deduped)
+	})
 
 }
 


### PR DESCRIPTION
Deduplicator.Deduplicate([]T) was returning a nil slice when provided an empty, but non-nil, slice. It has been fixed to return []T{} when []T{} is provided and nil when nil is provided