### PR TITLE
Bug fix: IncrementalBatch always returns empty batch when batchSize < 1

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -1,8 +1,9 @@
 package simpleflow
 
 import (
-	"github.com/stretchr/testify/suite"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type BatchSuite struct {
@@ -182,4 +183,24 @@ func (s *BatchSuite) TestIncrementalBatchMapFromPrePopulatedMap() {
 			s.Nil(batch)
 		}
 	}
+}
+
+func (s *BatchSuite) TestIncrementalBatchSliceLessThanOneBatchSize() {
+	for _, batchSize := range []int{-2, -1, 0, 1} {
+		items := []int{1}
+		remaining, batch := IncrementalBatchSlice(items, batchSize, 2)
+		// We can't know which one is returned due to indeterminate order or map iteration
+		s.Equal(remaining, []int{2})
+		s.Equal(batch, []int{1})
+	}
+}
+
+func (s *BatchSuite) TestIncrementalBatchMapLessThanOneBatchSize() {
+	for _, batchSize := range []int{-2, -1, 0, 1} {
+		items := map[int]int{1: 1}
+		batch := IncrementalBatchMap(items, batchSize, 2, 2)
+		// We can't know which one is returned due to indeterminate order or map iteration
+		s.Len(batch, 1)
+	}
+
 }

--- a/batches.go
+++ b/batches.go
@@ -52,7 +52,13 @@ func BatchChan[T any](items <-chan T, size int, to chan []T) {
 // IncrementalBatchSlice incrementally builds slice batches of size `batchSize` by appending to a slice
 // If the slice is larger than `batchSize` elements, a single batch is returned. The remaining
 // elements of the slice are always returned. Batched items are returned from the head of the slice.
+// To avoid errors on the caller side,  passing a batchSize < 1 will result in a batchSize of 1.
 func IncrementalBatchSlice[T any](items []T, batchSize int, v T) (remaining, batch []T) {
+	// prevent bugs on the caller side by using a minimum of 1 batchSize
+	if batchSize < 1 {
+		batchSize = 1
+	}
+
 	items = append(items, v)
 	if len(items) >= batchSize {
 		remaining = items[batchSize:]
@@ -68,7 +74,12 @@ func IncrementalBatchSlice[T any](items []T, batchSize int, v T) (remaining, bat
 // If the map is larger than `batchSize` elements, a single batch is returned along with the remaining
 // elements of the map. Batched items are chosen by iterating the (unordered) map and thus you cannot make
 // assumptions on which keys will exist in the batch.
+// To avoid errors on the caller side,  passing a batchSize < 1 will result in a batchSize of 1.
 func IncrementalBatchMap[K comparable, V any](items map[K]V, batchSize int, k K, v V) (batch map[K]V) {
+	// prevent bugs on the caller side by using a minimum of 1 batchSize
+	if batchSize < 1 {
+		batchSize = 1
+	}
 	items[k] = v
 	if len(items) >= batchSize {
 		batch = make(map[K]V, batchSize)


### PR DESCRIPTION
Fixed an issue where passing a batchSize < 1 to IncrementalBatchSlice/Map was causing them to always return empty batches. Added a check that will use batchSize = 1 if it detects < 1 passed in.